### PR TITLE
Fixed the bug that manages without an Alias are not able to open the Details-Form

### DIFF
--- a/PokemonGoGUI/UI/MainForm.cs
+++ b/PokemonGoGUI/UI/MainForm.cs
@@ -103,7 +103,7 @@ namespace PokemonGoGUI
             foreach (Manager manager in managers)
             {
                 var checkWindow = new ConsoleHelper();
-                var window = checkWindow.FindWindowByCaption(manager.AccountName);
+                var window = checkWindow.FindWindowByCaption(manager.UserSettings.Username);
 
                 if (window == IntPtr.Zero)
                 {


### PR DESCRIPTION
If the Manager do not have an Alias, the Details are not able open. Now it uses the accountname to ref it.
Tested with PTC. 
Unsure about Google-Accounts